### PR TITLE
Only call findMany when it's required

### DIFF
--- a/src/connectionResolver.js
+++ b/src/connectionResolver.js
@@ -86,6 +86,7 @@ export function prepareConnectionResolver(
     },
     resolve: async (resolveParams: ConnectionResolveParams) => {
       let countPromise;
+      let findManyPromise;
       const { projection = {}, args, rawQuery } = resolveParams;
       const findManyParams: ResolveParams = Object.assign(
         {},
@@ -117,6 +118,13 @@ export function prepareConnectionResolver(
         countPromise = Promise.resolve(0);
       }
 
+      let onlyCountProjected = projection.count;
+      for (var property in projection) {
+          if (projection.hasOwnProperty(property) && property !== 'count') {
+            onlyCountProjected = false;
+            break;
+          }
+      }
 
       if (projection && projection.edges) {
         // combine top level projection (maybe somebody add additional fields via resolveParams.projection)
@@ -173,7 +181,15 @@ export function prepareConnectionResolver(
       resolveParams.findManyResolveParams = findManyParams;
       resolveParams.countResolveParams = countParams;
 
-      return Promise.all([findManyResolve(findManyParams), countPromise])
+      // This allows to optimize and not actually call the findMany resolver
+      // if only the count is required
+      if (onlyCountProjected) {
+        findManyPromise = Promise.resolve([]);
+      } else {
+        findManyPromise = findManyResolve(findManyParams);
+      }
+
+      return Promise.all([findManyPromise, countPromise])
         .then(([recordList, count]) => {
           const edges = [];
           // transform record to object { cursor, node }

--- a/src/connectionResolver.js
+++ b/src/connectionResolver.js
@@ -118,14 +118,6 @@ export function prepareConnectionResolver(
         countPromise = Promise.resolve(0);
       }
 
-      let onlyCountProjected = projection.count;
-      for (var property in projection) {
-          if (projection.hasOwnProperty(property) && property !== 'count') {
-            onlyCountProjected = false;
-            break;
-          }
-      }
-
       if (projection && projection.edges) {
         // combine top level projection (maybe somebody add additional fields via resolveParams.projection)
         // and edges.node (record needed fields)
@@ -182,8 +174,8 @@ export function prepareConnectionResolver(
       resolveParams.countResolveParams = countParams;
 
       // This allows to optimize and not actually call the findMany resolver
-      // if only the count is required
-      if (onlyCountProjected) {
+      // if only the count is projected
+      if (projection.count && Object.keys(projection).length == 1) {
         findManyPromise = Promise.resolve([]);
       } else {
         findManyPromise = findManyResolve(findManyParams);


### PR DESCRIPTION
When only `count` field is requested - only call the count resolver.

I had to modify the tests and add some more tests.
Also, I could not easily avoid all the sorting/cursor logic since some other tests depend on the resolver to modify the resolveParams (even if the findMany is not called).
So left all logic except for the actual resolve execution.

This should address #5 