### PR TITLE
Yield the correct dataset for last+before args

### DIFF
--- a/src/__tests__/connectionResolver-test.js
+++ b/src/__tests__/connectionResolver-test.js
@@ -598,6 +598,19 @@ describe('connectionResolver', () => {
         expect(conn.edges[0].node.id).toBe(result.edges[2].node.id);
       });
     });
+
+    it('should return previous edges when querying with last and before', async () => {
+      const result = await connectionResolver.resolve({
+        args: {
+          sort: sortOptions.ID_ASC.value,
+          before: dataToCursor({ id: 4 }),
+          last: 2,
+        },
+      });
+      expect(result.edges).toHaveLength(2);
+      expect(result.edges[0].node.id).toBe(2);
+      expect(result.edges[1].node.id).toBe(3);
+    });
   });
 
   describe('how works filter argument with resolve', () => {


### PR DESCRIPTION
Proposal targeting the issue #7

In backward situations with cursors, the resolver uses "count" to compute the "skip" value and forward it to the findMany resolver. If the count value is the global one, and not the one with the rawQuery with the '$lt' statement, the value is incorrect. Hence the invalid dataset.

The PR contains: 
- a test to highlight the problem.
- a modification of the connectionResolver : I got the sortConfig and the prepareRawQuery parts a little bit sooner to correct the count in that specific case. 